### PR TITLE
fix index-url and extra-index-url part of install master package command

### DIFF
--- a/src/dbxdeploy/package/PackageInstaller.py
+++ b/src/dbxdeploy/package/PackageInstaller.py
@@ -34,7 +34,7 @@ class PackageInstaller:
             "import IPython\n\n"
             'if "DAIPE_BOOTSTRAPPED" not in os.environ:\n'
             "    IPython.get_ipython().run_line_magic"
-            f'("pip", "install {self.__modify_dbfs(package_file_path)} {pip_options}")  # noqa'
+            f'("pip", f"install {self.__modify_dbfs(package_file_path)} {pip_options}")  # noqa'
         )
 
     def __get_online_install_command(self, package_file_path: str):

--- a/src/dbxdeploy/package/PackageInstaller.py
+++ b/src/dbxdeploy/package/PackageInstaller.py
@@ -66,7 +66,7 @@ class PackageInstaller:
 
         if "@" not in parsed_url.netloc:
             parsed_url = parsed_url._replace(
-                netloc=f'{{os.getenv("{username_env_var_name}")}}:{{os.getenv("{password_env_var_name}")}}@{parsed_url.netloc}'
+                netloc=f"{{os.getenv('{username_env_var_name}')}}:{{os.getenv('{password_env_var_name}')}}@{parsed_url.netloc}"
             )
 
         return f"--index-url {parsed_url.geturl()}"
@@ -84,7 +84,7 @@ class PackageInstaller:
 
             if "@" not in parsed_url.netloc:
                 parsed_url = parsed_url._replace(
-                    netloc=f'{{os.getenv("{username_env_var_name}")}}:{{os.getenv("{password_env_var_name}")}}@{parsed_url.netloc}'
+                    netloc=f"{{os.getenv('{username_env_var_name}')}}:{{os.getenv('{password_env_var_name}')}}@{parsed_url.netloc}"
                 )
 
             extra_indexes_to_return.append(f"--extra-index-url {parsed_url.geturl()}")


### PR DESCRIPTION
Hi,
we also discovered another bug with install master package command. In the current version, when index-url or extra-index-url (e.g.
```toml
[[tool.poetry.source]]
name = 'default'
url = 'https://pypi.python.org/simple'
default = true

[[tool.poetry.source]]
name = 'devops'
url = 'https://pkgs.dev.azure.com/<org>/_packaging/<org>/pypi/simple/'
secondary = true
```
in `pyproject.toml`) are configured, the resulting command in `install_master_package.py` is something along the lines of
```python
# %install_master_package_whl
import os
import IPython

if "DAIPE_BOOTSTRAPPED" not in os.environ:
    IPython.get_ipython().run_line_magic("pip", "install /dbfs/FileStore/jars/test_project/2021-12-16_10-49-31_wxccnzrzul/test_project-0.1.20211216104931402623-py3-none-any.whl --index-url https://{os.getenv("DATABRICKS_HTTP_BASIC_DEFAULT_USERNAME")}:{os.getenv("DATABRICKS_HTTP_BASIC_DEFAULT_PASSWORD")}@pypi.python.org/simple --extra-index-url https://{os.getenv("DATABRICKS_HTTP_BASIC_DEVOPS_USERNAME")}:{os.getenv("DATABRICKS_HTTP_BASIC_DEVOPS_PASSWORD")}@pkgs.dev.azure.com/<org>/_packaging/<org>/pypi/simple/")  # noqa
```
which is invalid (invalid quotations) => syntax error.

A simple quoting change should remedy this issue