### PR TITLE
dbx-deploy paths fix & repo force update

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -159,6 +159,21 @@ pyfony-core = ">=0.8.0,<0.9.0"
 python-dotenv = ">=0.13.0,<1.0.0"
 
 [[package]]
+name = "daipe-core"
+version = "1.3.3"
+description = "Daipe framework core"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+console-bundle = ">=0.5,<0.6"
+injecta = ">=0.10.0,<0.11.0"
+logger-bundle = ">=0.7.0,<0.8.0"
+pandas = ">=1.0.1,<2.0.0"
+pyfony-bundles = ">=0.4.0,<0.5.0"
+
+[[package]]
 name = "databricks-cli"
 version = "0.16.0"
 description = "A command line interface for Databricks"
@@ -377,6 +392,18 @@ pywin32 = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 traitlets = "*"
 
 [[package]]
+name = "logger-bundle"
+version = "0.7.0"
+description = "Logger bundle for the Pyfony framework"
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+colorlog = ">=4.0,<5.0"
+pyfony-bundles = ">=0.4.0,<0.5.0"
+
+[[package]]
 name = "markupsafe"
 version = "1.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -462,6 +489,14 @@ traitlets = ">=4.1"
 test = ["testpath", "pytest", "pytest-cov"]
 
 [[package]]
+name = "numpy"
+version = "1.21.1"
+description = "NumPy is the fundamental package for array computing with Python."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
 name = "packaging"
 version = "20.1"
 description = "Core utilities for Python packages"
@@ -472,6 +507,22 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
+
+[[package]]
+name = "pandas"
+version = "1.1.5"
+description = "Powerful data structures for data analysis, time series, and statistics"
+category = "main"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+numpy = ">=1.15.4"
+python-dateutil = ">=2.7.3"
+pytz = ">=2017.2"
+
+[package.extras]
+test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
 
 [[package]]
 name = "pandocfilters"
@@ -714,6 +765,17 @@ python-versions = "*"
 testing = ["pytest", "coverage (>=3.6)", "pytest-cov"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "python-dotenv"
 version = "0.15.0"
 description = "Add .env support to your django/flask apps in development and deployments"
@@ -723,6 +785,14 @@ python-versions = "*"
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "pytz"
+version = "2021.3"
+description = "World timezone definitions, modern and historical"
+category = "main"
+optional = false
+python-versions = "*"
 
 [[package]]
 name = "pywin32"
@@ -888,7 +958,7 @@ testing = ["jaraco.itertools"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "fddede4713638fba7d754fe90fa0f2dda498eeef8302c39c27eb86cad87a74d8"
+content-hash = "fe7562e2badc6144084995a6a16be0b71c4c2e132988c4567e81fe3707addf4f"
 
 [metadata.files]
 appdirs = [
@@ -975,6 +1045,9 @@ colorlog = [
 console-bundle = [
     {file = "console_bundle-0.5.0-py3-none-any.whl", hash = "sha256:209351f03f19796c1677cae38416d6ffbf8158c2c217cf85f0e0c3f5ff16b7c2"},
 ]
+daipe-core = [
+    {file = "daipe_core-1.3.3-py3-none-any.whl", hash = "sha256:0232faa27dd22957ffd5ced4f67f31b469060114aab72fc2457b9c5383a97cf3"},
+]
 databricks-cli = [
     {file = "databricks-cli-0.16.0.tar.gz", hash = "sha256:d8338597cec0f1d6d979a5ea2018cf6a134c8f991f6054656e82f995b6c6ab82"},
     {file = "databricks_cli-0.16.0-py2-none-any.whl", hash = "sha256:7755acd2684b0699a5948253a799f0a952ddee5dbc59b096ecb60e30443b8642"},
@@ -1041,6 +1114,9 @@ jsonschema = [
 jupyter-core = [
     {file = "jupyter_core-4.6.2-py2.py3-none-any.whl", hash = "sha256:e91785b8bd7f752711c0c20e5ec6ba0d42178d6321a61396082c55818991caee"},
     {file = "jupyter_core-4.6.2.tar.gz", hash = "sha256:185dfe42800585ca860aa47b5fe0211ee2c33246576d2d664b0b0b8d22aacf3a"},
+]
+logger-bundle = [
+    {file = "logger_bundle-0.7.0-py3-none-any.whl", hash = "sha256:699b3ff0454ae6db1a2ec510002583e10d213d02bab4a29a78ea59ab74a14133"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -1120,9 +1196,65 @@ nbformat = [
     {file = "nbformat-5.0.4-py3-none-any.whl", hash = "sha256:f4bbbd8089bd346488f00af4ce2efb7f8310a74b2058040d075895429924678c"},
     {file = "nbformat-5.0.4.tar.gz", hash = "sha256:562de41fc7f4f481b79ab5d683279bf3a168858268d4387b489b7b02be0b324a"},
 ]
+numpy = [
+    {file = "numpy-1.21.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671"},
+    {file = "numpy-1.21.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e"},
+    {file = "numpy-1.21.1-cp37-cp37m-win32.whl", hash = "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172"},
+    {file = "numpy-1.21.1-cp37-cp37m-win_amd64.whl", hash = "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267"},
+    {file = "numpy-1.21.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68"},
+    {file = "numpy-1.21.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8"},
+    {file = "numpy-1.21.1-cp38-cp38-win32.whl", hash = "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd"},
+    {file = "numpy-1.21.1-cp38-cp38-win_amd64.whl", hash = "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b"},
+    {file = "numpy-1.21.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1"},
+    {file = "numpy-1.21.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a"},
+    {file = "numpy-1.21.1-cp39-cp39-win32.whl", hash = "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2"},
+    {file = "numpy-1.21.1-cp39-cp39-win_amd64.whl", hash = "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33"},
+    {file = "numpy-1.21.1-pp37-pypy37_pp73-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4"},
+    {file = "numpy-1.21.1.zip", hash = "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd"},
+]
 packaging = [
     {file = "packaging-20.1-py2.py3-none-any.whl", hash = "sha256:170748228214b70b672c581a3dd610ee51f733018650740e98c7df862a583f73"},
     {file = "packaging-20.1.tar.gz", hash = "sha256:e665345f9eef0c621aa0bf2f8d78cf6d21904eef16a93f020240b704a57f1334"},
+]
+pandas = [
+    {file = "pandas-1.1.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:bf23a3b54d128b50f4f9d4675b3c1857a688cc6731a32f931837d72effb2698d"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5a780260afc88268a9d3ac3511d8f494fdcf637eece62fb9eb656a63d53eb7ca"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b61080750d19a0122469ab59b087380721d6b72a4e7d962e4d7e63e0c4504814"},
+    {file = "pandas-1.1.5-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:0de3ddb414d30798cbf56e642d82cac30a80223ad6fe484d66c0ce01a84d6f2f"},
+    {file = "pandas-1.1.5-cp36-cp36m-win32.whl", hash = "sha256:70865f96bb38fec46f7ebd66d4b5cfd0aa6b842073f298d621385ae3898d28b5"},
+    {file = "pandas-1.1.5-cp36-cp36m-win_amd64.whl", hash = "sha256:19a2148a1d02791352e9fa637899a78e371a3516ac6da5c4edc718f60cbae648"},
+    {file = "pandas-1.1.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26fa92d3ac743a149a31b21d6f4337b0594b6302ea5575b37af9ca9611e8981a"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c16d59c15d946111d2716856dd5479221c9e4f2f5c7bc2d617f39d870031e086"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3be7a7a0ca71a2640e81d9276f526bca63505850add10206d0da2e8a0a325dae"},
+    {file = "pandas-1.1.5-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:573fba5b05bf2c69271a32e52399c8de599e4a15ab7cec47d3b9c904125ab788"},
+    {file = "pandas-1.1.5-cp37-cp37m-win32.whl", hash = "sha256:21b5a2b033380adbdd36b3116faaf9a4663e375325831dac1b519a44f9e439bb"},
+    {file = "pandas-1.1.5-cp37-cp37m-win_amd64.whl", hash = "sha256:24c7f8d4aee71bfa6401faeba367dd654f696a77151a8a28bc2013f7ced4af98"},
+    {file = "pandas-1.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2860a97cbb25444ffc0088b457da0a79dc79f9c601238a3e0644312fcc14bf11"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5008374ebb990dad9ed48b0f5d0038124c73748f5384cc8c46904dace27082d9"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2c2f7c670ea4e60318e4b7e474d56447cf0c7d83b3c2a5405a0dbb2600b9c48e"},
+    {file = "pandas-1.1.5-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:0a643bae4283a37732ddfcecab3f62dd082996021b980f580903f4e8e01b3c5b"},
+    {file = "pandas-1.1.5-cp38-cp38-win32.whl", hash = "sha256:5447ea7af4005b0daf695a316a423b96374c9c73ffbd4533209c5ddc369e644b"},
+    {file = "pandas-1.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:4c62e94d5d49db116bef1bd5c2486723a292d79409fc9abd51adf9e05329101d"},
+    {file = "pandas-1.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:731568be71fba1e13cae212c362f3d2ca8932e83cb1b85e3f1b4dd77d019254a"},
+    {file = "pandas-1.1.5-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c61c043aafb69329d0f961b19faa30b1dab709dd34c9388143fc55680059e55a"},
+    {file = "pandas-1.1.5-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2b1c6cd28a0dfda75c7b5957363333f01d370936e4c6276b7b8e696dd500582a"},
+    {file = "pandas-1.1.5-cp39-cp39-win32.whl", hash = "sha256:c94ff2780a1fd89f190390130d6d36173ca59fcfb3fe0ff596f9a56518191ccb"},
+    {file = "pandas-1.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:edda9bacc3843dfbeebaf7a701763e68e741b08fccb889c003b0a52f0ee95782"},
+    {file = "pandas-1.1.5.tar.gz", hash = "sha256:f10fc41ee3c75a474d3bdf68d396f10782d013d7f67db99c0efbfd0acb99701b"},
 ]
 pandocfilters = [
     {file = "pandocfilters-1.4.2.tar.gz", hash = "sha256:b3dd70e169bb5449e6bc6ff96aea89c5eea8c5f6ab5e207fc2f521a2cf4a0da9"},
@@ -1222,9 +1354,17 @@ python-box = [
     {file = "python-box-3.4.6.tar.gz", hash = "sha256:694a7555e3ff9fbbce734bbaef3aad92b8e4ed0659d3ed04d56b6a0a0eff26a9"},
     {file = "python_box-3.4.6-py2.py3-none-any.whl", hash = "sha256:a71d3dc9dbaa34c8597d3517c89a8041bd62fa875f23c0f3dad55e1958e3ce10"},
 ]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
 python-dotenv = [
     {file = "python-dotenv-0.15.0.tar.gz", hash = "sha256:587825ed60b1711daea4832cf37524dfd404325b7db5e25ebe88c495c9f807a0"},
     {file = "python_dotenv-0.15.0-py2.py3-none-any.whl", hash = "sha256:0c8d1b80d1a1e91717ea7d526178e3882732420b03f08afea0406db6402e220e"},
+]
+pytz = [
+    {file = "pytz-2021.3-py2.py3-none-any.whl", hash = "sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c"},
+    {file = "pytz-2021.3.tar.gz", hash = "sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326"},
 ]
 pywin32 = [
     {file = "pywin32-302-cp310-cp310-win32.whl", hash = "sha256:251b7a9367355ccd1a4cd69cd8dd24bd57b29ad83edb2957cfa30f7ed9941efa"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pyfony-core = "^0.8.1"
 console-bundle = "^0.5"
 Jinja2 = "^2.0.0"
 databricks-cli = "^0.16.0"
+daipe-core = ">=1.0.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/src/dbxdeploy/_config/config.yaml
+++ b/src/dbxdeploy/_config/config.yaml
@@ -24,8 +24,9 @@ parameters:
         release_path: '%dbxdeploy.target.workspace.base_dir%/{current_time}_{random_string}'
         current_path: '%dbxdeploy.target.workspace.base_dir%/_current'
       repo:
-        root_dir: "/Repos/%daipe.root_module.name%-%kernel.environment%"
-        path: "%dbxdeploy.target.repo.root_dir%/{repo_name}"
+        root_dir: # @deprecated, use base_dir instead - will be removed in 2.0
+        path: # @deprecated, use base_dir instead - will be removed in 2.0
+        base_dir: '/Repos/%daipe.root_module.name%-%kernel.environment%/{branch_name}' # to be changed to "/Repos/{repo_name}/{branch_name}" in 2.0
       package:
         base_dir: 'dbfs:/FileStore/jars'
         deploy_path: '%dbxdeploy.target.package.base_dir%/{package_name}/{current_time}_{random_string}/{package_filename}'
@@ -389,6 +390,7 @@ services:
     arguments:
       - '%dbxdeploy.target.repo.root_dir%'
       - '%dbxdeploy.target.repo.path%'
+      - '%dbxdeploy.target.repo.base_dir%'
       - '@consolebundle.logger'
 
   dbxdeploy.repos.RepoUpdateCommand:

--- a/src/dbxdeploy/_config/config_test.yaml
+++ b/src/dbxdeploy/_config/config_test.yaml
@@ -10,5 +10,3 @@ parameters:
     target:
       workspace:
         base_dir: '/foobar/master'
-      repo:
-        root_dir: '/Repos/foobar'

--- a/src/dbxdeploy/repos/RepoDeleteCommand.py
+++ b/src/dbxdeploy/repos/RepoDeleteCommand.py
@@ -1,6 +1,7 @@
 from argparse import Namespace, ArgumentParser
 from consolebundle.ConsoleCommand import ConsoleCommand
 from dbxdeploy.repos.RepoManager import RepoManager
+from dbxdeploy.repos import argparser_configurator
 
 
 class RepoDeleteCommand(ConsoleCommand):
@@ -14,12 +15,10 @@ class RepoDeleteCommand(ConsoleCommand):
         return "Deletes a repository on DBX if available"
 
     def configure(self, argument_parser: ArgumentParser):
-        required_args = argument_parser.add_argument_group("required arguments")
-        required_args.add_argument("--repo-url", dest="repo_url", help="Project repo url")
-        required_args.add_argument("--repo-name", dest="repo_name", help="Project repo name")
+        argparser_configurator.add_common_repos_args(argument_parser)
 
     def run(self, input_args: Namespace):
-        if not (input_args.repo_url and input_args.repo_name):
-            raise Exception("All arguments are required. Check -h for the list of required arguments.")
+        if not input_args.repo_url:
+            raise Exception("Missed required arguments. Check -h for the list of required arguments.")
 
-        self.__repo_manager.delete(input_args.repo_url, input_args.repo_name)
+        self.__repo_manager.delete(input_args.repo_url, input_args.repo_name, input_args.branch, input_args.tag)

--- a/src/dbxdeploy/repos/RepoManager.py
+++ b/src/dbxdeploy/repos/RepoManager.py
@@ -1,6 +1,7 @@
+import os
 import urllib3
-from requests.exceptions import HTTPError
 from logging import Logger
+from requests.exceptions import HTTPError
 from databricks_cli.repos.api import ReposApi
 from databricks_cli.workspace.api import WorkspaceApi
 
@@ -10,36 +11,41 @@ class RepoManager:
         self,
         repo_root_dir: str,
         repo_path: str,
+        repo_base_dir: str,
         logger: Logger,
         repos_api: ReposApi,
         workspace_api: WorkspaceApi,
     ):
+        if repo_root_dir is not None or repo_path is not None:
+            raise Exception(
+                "dbxdeploy.target.repo.root_dir and dbxdeploy.target.repo.path are deprecated, please use dbxdeploy.target.repo.base_dir instead"
+            )
+
+        self.__repo_base_dir = repo_base_dir
+        self.__logger = logger
         self.__repos_api = repos_api
         self.__workspace_api = workspace_api
-        self.__logger = logger
-        self.__repo_root_dir = repo_root_dir
-        self.__repo_path = repo_path
 
-    def create_or_update(self, repo_url, branch, tag, repo_name, force):
-        repo_path = self.__repo_path.format(repo_name=repo_name)
+    def create_or_update(self, repo_url, repo_name=None, branch=None, tag=None, force=False):
+        repo_path = self.__resolve_repo_path(repo_name, branch, tag)
+        repo_group_path = os.path.split(repo_path)[0]
         self.__logger.info(f"Updating repo at {repo_path}")
-        self.__workspace_api.mkdirs(self.__repo_root_dir)
+        self.__workspace_api.mkdirs(repo_group_path)
 
-        repo_list = self.__repos_api.list(self.__repo_root_dir, None).get("repos", [])
+        repo_list = self.__repos_api.list(repo_group_path, None).get("repos", [])
+        self.__check_duplicated_branches(repo_list)
 
         try:
             repo_id = self.__repos_api.get_repo_id(repo_path)
-            self.__check_duplicates(repo_list)
+        except RuntimeError:
+            self.__logger.info("Repo not found, cloning new repo")
+            repo_id = self.__repos_api.create(url=repo_url, provider=self.__get_provider_from_url(repo_url), path=repo_path)["id"]
+        else:
             self.__check_correct_project(repo_id, repo_url)
             if force:
                 self.__logger.info("Re-cloning repo")
                 self.__repos_api.delete(repo_id)
                 repo_id = self.__repos_api.create(url=repo_url, provider=self.__get_provider_from_url(repo_url), path=repo_path)["id"]
-        except RuntimeError:
-            self.__logger.info("Repo not found, cloning new repo")
-            self.__check_duplicates(repo_list)
-            self.__check_valid_branch(repo_list, branch)
-            repo_id = self.__repos_api.create(url=repo_url, provider=self.__get_provider_from_url(repo_url), path=repo_path)["id"]
 
         try:
             self.__repos_api.update(repo_id=repo_id, branch=branch, tag=tag)
@@ -48,39 +54,43 @@ class RepoManager:
                 self.__logger.info("Error occurred, cleaning up ...")
                 self.__repos_api.delete(repo_id)
             raise e
+        else:
+            self.__logger.info("Repo successfully updated")
 
-        self.__logger.info("Repo successfully updated")
-
-    def delete(self, repo_url, repo_name):
-        repo_path = self.__repo_path.format(repo_name=repo_name)
-
+    def delete(self, repo_url, repo_name=None, branch=None, tag=None):
+        repo_path = self.__resolve_repo_path(repo_name, branch, tag)
         self.__logger.info(f"Deleting repo at {repo_path}")
 
         try:
             repo_id = self.__repos_api.get_repo_id(repo_path)
-            self.__check_correct_project(repo_id, repo_url)
         except RuntimeError:
             self.__logger.info("Repo not found, skipping delete")
         else:
+            self.__check_correct_project(repo_id, repo_url)
             self.__repos_api.delete(repo_id)
             self.__logger.info("Repo successfully deleted")
+
+    def __resolve_repo_path(self, repo_name, branch, tag):
+        self.__validate_placeholder_arguments("{repo_name}", repo_name, "--repo_name")
+        self.__validate_placeholder_arguments("{branch_name}", branch, "--branch")
+        self.__validate_placeholder_arguments("{tag_name}", tag, "--tag")
+        return self.__repo_base_dir.format(repo_name=repo_name, branch_name=branch, tag_name=tag)
+
+    def __validate_placeholder_arguments(self, placeholder, argument, argument_name):
+        if argument is None and placeholder in self.__repo_base_dir:
+            raise Exception(f"{placeholder} used in repo.base_dir, but {argument_name} argument was not provided")
 
     def __check_correct_project(self, repo_id, repo_url):
         repo = self.__repos_api.get(repo_id)
         if repo_url != repo["url"]:
             raise Exception(f"Repo at {repo['path']} has source at {repo['url']}, expected {repo_url}")
 
-    def __check_duplicates(self, repo_list: list):
+    def __check_duplicated_branches(self, repo_list: list):
         repo_branches = [repo.get("branch") for repo in repo_list]
         branch_counter = [{"name": branch, "count": repo_branches.count(branch)} for branch in set(repo_branches)]
         duplicated_branches = [branch["name"] for branch in branch_counter if branch["count"] > 1]
         if len(duplicated_branches) > 0:
             raise Exception(f"Following branches are duplicated in current env: {', '.join(duplicated_branches)}.")
-
-    def __check_valid_branch(self, repo_list: list, branch: str):
-        repo_branches = [repo.get("branch") for repo in repo_list]
-        if branch in repo_branches:
-            raise Exception(f"Branch {branch} is already present in current env.")
 
     def __get_provider_from_url(self, url):
         provider_map = {

--- a/src/dbxdeploy/repos/RepoUpdateCommand.py
+++ b/src/dbxdeploy/repos/RepoUpdateCommand.py
@@ -1,6 +1,7 @@
 from argparse import Namespace, ArgumentParser
 from consolebundle.ConsoleCommand import ConsoleCommand
 from dbxdeploy.repos.RepoManager import RepoManager
+from dbxdeploy.repos import argparser_configurator
 
 
 class RepoUpdateCommand(ConsoleCommand):
@@ -14,26 +15,18 @@ class RepoUpdateCommand(ConsoleCommand):
         return "Pulls and checkouts the current branch of a repo on DBX"
 
     def configure(self, argument_parser: ArgumentParser):
-        required_args = argument_parser.add_argument_group("required arguments")
-        required_choice_args = argument_parser.add_argument_group("required one of these")
-        optional_args = argument_parser.add_argument_group("optional arguments")
-        required_args.add_argument("--repo-url", dest="repo_url", help="Project repo url")
-        required_args.add_argument("--repo-name", dest="repo_name", help="Project repo name")
-        required_choice_args.add_argument("--branch", dest="branch", help="Branch to checkout")
-        required_choice_args.add_argument("--tag", dest="tag", help="Tag to checkout")
-        optional_args.add_argument("--force", "-f", dest="force", action="store_true", help="Force update")
-        optional_args.set_defaults(force=False)
+        argparser_configurator.add_common_repos_args(argument_parser)
+        argument_parser.add_argument("--force", "-f", dest="force", action="store_true", help="Force update")
+        argument_parser.set_defaults(force=False)
 
     def run(self, input_args: Namespace):
-        if not (input_args.repo_url and input_args.repo_name) or not (input_args.branch or input_args.tag):
+        if not input_args.repo_url:
             raise Exception("Missed required arguments. Check -h for the list of required arguments.")
-        if input_args.branch and input_args.tag:
-            raise Exception("Can't pick both --checkout-branch and --checkout-tag. Check -h for details.")
 
         self.__repo_manager.create_or_update(
             input_args.repo_url,
+            input_args.repo_name,
             input_args.branch,
             input_args.tag,
-            input_args.repo_name,
             input_args.force,
         )

--- a/src/dbxdeploy/repos/argparser_configurator.py
+++ b/src/dbxdeploy/repos/argparser_configurator.py
@@ -1,0 +1,8 @@
+from argparse import ArgumentParser
+
+
+def add_common_repos_args(argument_parser: ArgumentParser):
+    argument_parser.add_argument("--repo-url", dest="repo_url", help="Project repo url")
+    argument_parser.add_argument("--repo-name", dest="repo_name", help="Project repo name")
+    argument_parser.add_argument("--branch", dest="branch", help="Branch to checkout")
+    argument_parser.add_argument("--tag", dest="tag", help="Tag to checkout")


### PR DESCRIPTION
* `dbxdeploy.target.repo.root_dir` and `dbxdeploy.target.repo.path` deprecated in `dbxdeploy.target.repo.base_dir`
* `dbx:repo:update` command now supports the `--force` argument to force update of a repo in Databricks repo (similar to `git reset --hard`)
